### PR TITLE
Convert UID tests to pytest

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+from click.testing import CliRunner
+
+import socx
+from socx.cli import cli
+
+
+def test_version_command_outputs_project_name() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["version"])
+    assert result.exit_code == 0
+    assert socx.settings.metadata.__project__ in result.output
+
+
+def test_version_command_is_listed_in_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "version" in result.output

--- a/tests/test_uid.py
+++ b/tests/test_uid.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
+import gc
+
 from socx import UIDMixin
-from socx import console
 
 
 @dataclass
@@ -8,19 +9,21 @@ class UIDTest(UIDMixin):
     iteration: int
 
 
-def test() -> None:
-    inst_ = UIDTest(0)
-    for _ in range(1, 999):
-        inst = UIDTest(_)
-        assert inst.iteration == inst.uid
-        console.print(UIDTest.dref(inst.ref))
+def test_uid_increments_and_deref() -> None:
+    first = UIDTest(0)
+    assert first.uid == 0
+    assert UIDTest.dref(first.ref) is first
+
+    for i in range(1, 5):
+        inst = UIDTest(i)
+        assert inst.uid == i
+        assert UIDTest.dref(inst.ref) is inst
+        ref = inst.ref
         del inst
-        console.print(UIDTest.dref(_))
+        gc.collect()
+        assert UIDTest.dref(ref) is None
 
-    console.print(UIDTest.dref(inst_.ref))
-    del inst_
-    console.print(UIDTest.dref(0))
-
-
-if __name__ == "__main__":
-    test()
+    ref_first = first.ref
+    del first
+    gc.collect()
+    assert UIDTest.dref(ref_first) is None


### PR DESCRIPTION
## Summary
- convert UID test to real pytest assertions
- add a test that runs the version plugin using a real socx import
- ensure the version command is listed in help output

## Testing
- `uv sync --dev`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684343d78c58832b9d989a96c469c9a9