### PR TITLE
ci(deploy-docs): fix 'Sync Dependencies' stage

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: 3.14
       - name: Sync dependencies
-        run: uv sync --locked --all-extras --dev
+        run: make sync
       - name: Build documentation
         run: uv run zensical build --clean
       - uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
Use `make sync` instead of manually crafting the appropriate `uv sync` command flags