### PR TITLE
Add pluggable RegressionManager, runners and serializers; TUI restart scope and soft_reset test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@
 !*.yaml
 !*.toml
 !*.json
-!*.example
 
 !LICENSE
 !Makefile
@@ -50,3 +49,5 @@
 !CHANGELOG.md
 !CONTRIBUTING.md
 !CODE_OF_CONDUCT.md
+
+workrun/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ socx = 'socx.__main__:main'
 [project]
 name = "socx-cli"
 readme = "README.md"
-version = "0.13.2"
+version = "0.13.3"
 license = "Apache-2.0"
 authors = [{ name = "Sagi Kimhi", email = "sagi.kim5@gmail.com" }]
 maintainers = [{ name = "Sagi Kimhi", email = "sagi.kim5@gmail.com" }]

--- a/src/socx/regression/__init__.py
+++ b/src/socx/regression/__init__.py
@@ -8,6 +8,7 @@ __all__ = (
     "Regression",
     "RegressionTree",
     "RegressionProgress",
+    "RegressionManager",
 )
 
 from socx.regression.test import Test as Test
@@ -17,3 +18,5 @@ from socx.regression.test import TestResult as TestResult
 from socx.regression.regression import Regression as Regression
 from socx.regression.regression import RegressionTree as RegressionTree
 from socx.regression.progress import RegressionProgress as RegressionProgress
+
+from socx.regression.manager import RegressionManager as RegressionManager

--- a/src/socx/regression/manager.py
+++ b/src/socx/regression/manager.py
@@ -1,0 +1,127 @@
+"""Regression manager orchestrating execution and persistence concerns."""
+
+from __future__ import annotations
+
+import asyncio as aio
+import logging
+import time
+
+from socx.regression.runners import (
+    default_regression_runner,
+    default_test_runner,
+)
+from socx.regression.serializers import default_regression_serializer
+from socx.regression.test import TestStatus
+
+
+logger = logging.getLogger(__name__)
+
+
+class RegressionManager:
+    """Coordinates running, restarting and persisting regression objects."""
+
+    def __init__(self, runner=None, serializer=None, test_runner=None):
+        self.runner = runner or default_regression_runner
+        self.serializer = serializer or default_regression_serializer
+        self.test_runner = test_runner or default_test_runner
+
+    async def start(self, regression, runner=None) -> None:
+        if regression.status is TestStatus.Paused:
+            await self.resume(regression)
+            return
+
+        if regression.started and regression.status is not TestStatus.Pending:
+            return
+
+        regression._stop_requested = False
+        regression._pause_event.set()
+        regression._running.clear()
+        regression._done = aio.Queue()
+        regression._pending = aio.Queue()
+        regression.finished_time = None
+        if regression.started_time is None:
+            regression.started_time = time.time()
+
+        chosen_runner = runner or self.runner
+        try:
+            await chosen_runner.run(regression)
+        finally:
+            regression.finished_time = time.time()
+            regression._pause_event.set()
+            regression._running.clear()
+            logger.info(f"regression {regression.status.name.lower()}.")
+
+    async def pause(self, regression) -> None:
+        if regression.status is not TestStatus.Running:
+            return
+
+        regression._pause_event.clear()
+        await aio.gather(
+            *(test.pause() for test in regression._active_tests()),
+            return_exceptions=True,
+        )
+
+    async def resume(self, regression) -> None:
+        if regression.status is not TestStatus.Paused:
+            return
+
+        regression._pause_event.set()
+        await aio.gather(
+            *(test.resume() for test in regression.tests),
+            return_exceptions=True,
+        )
+
+    async def stop(self, regression) -> None:
+        if regression.status is TestStatus.Terminated:
+            return
+
+        regression._stop_requested = True
+        regression._pause_event.set()
+        await aio.gather(*(test.stop() for test in regression.tests), return_exceptions=True)
+
+    async def restart(self, regression) -> None:
+        await self.stop(regression)
+        self.reset(regression)
+        await self.start(regression)
+
+    def reset(self, regression) -> None:
+        super(type(regression), regression).reset()
+        for test in regression.tests:
+            if hasattr(test, "reset"):
+                test.reset()
+
+        regression._done = aio.Queue()
+        regression._pending = aio.Queue()
+        regression._pause_event = aio.Event()
+        regression._running.clear()
+        regression._stop_requested = False
+
+    def soft_reset(self, regression) -> None:
+        if regression.passed:
+            return
+
+        super(type(regression), regression).reset()
+        for test in regression.tests:
+            if hasattr(test, "soft_reset"):
+                test.soft_reset()
+
+        regression._done = aio.Queue()
+        regression._pending = aio.Queue()
+        regression._pause_event = aio.Event()
+        regression._running.clear()
+        regression._stop_requested = False
+
+    def dump_state(self, regression, output_dir=None):
+        logger.info("saving regression state and results to disk...")
+        file = self.serializer.dump_state(regression, output_dir=output_dir)
+        logger.info(f"state and results saved to: '{file}'.")
+        return file
+
+    def from_file(self, cls, path, name=None, test_cls=None, **kwargs):
+        return self.serializer.from_file(cls, path, name=name, test_cls=test_cls)
+
+    def load(self, cls, path, name=None, test_cls=None, **kwargs):
+        return self.serializer.load(cls, path, name=name, test_cls=test_cls)
+
+
+default_regression_manager = RegressionManager()

--- a/src/socx/regression/regression.py
+++ b/src/socx/regression/regression.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio as aio
 import anyio
 import logging
+import re
 import time
 from collections import OrderedDict
-from collections.abc import AsyncGenerator, Iterable
+from collections.abc import AsyncGenerator, Iterable, Mapping
 from pathlib import Path
 from threading import RLock
 from typing import Self, Any, Annotated
@@ -34,6 +35,25 @@ from socx.regression.test import Test, TestBase, TestResult, TestStatus
 logger = logging.getLogger(__name__)
 
 semaphore = anyio.Semaphore(max(1, settings.regression.max_runs_in_parallel))
+
+
+def _safe_dir_name(name: str, node_id: UUID4) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-").lower()
+    return f"{slug or 'item'}-{node_id}"
+
+
+def _coerce_status(value: TestStatus | int | str) -> TestStatus:
+    if isinstance(value, TestStatus):
+        return value
+    if isinstance(value, int):
+        return TestStatus(value)
+    return TestStatus[value.strip().lower().title()]
+
+
+def _coerce_result(value: TestResult | str) -> TestResult:
+    if isinstance(value, TestResult):
+        return value
+    return TestResult(value)
 
 
 class Regression(TestBase):
@@ -78,7 +98,28 @@ class Regression(TestBase):
         test_cls: type[TestBase] | None = None,
         **kwargs: Any,
     ) -> Self:
-        return cls._from_file(path, test_cls=test_cls, **kwargs)
+        return cls._from_file(path, name=name, test_cls=test_cls, **kwargs)
+
+    @classmethod
+    @validate_call()
+    def load(
+        cls,
+        path: str | Path,
+        name: str | None = None,
+        test_cls: type[TestBase] | None = None,
+        **kwargs: Any,
+    ) -> Self:
+        path = TypeAdapter(FilePath).validate_python(path)
+        data = cls._read_data(path)
+
+        if cls._looks_like_state(data):
+            return cls._from_state_data(
+                data,
+                output_dir=path.parent,
+                test_cls=test_cls or Test,
+            )
+
+        return cls._from_file(path, name=name, test_cls=test_cls, **kwargs)
 
     @computed_field
     @property
@@ -187,7 +228,7 @@ class Regression(TestBase):
         self._done = aio.Queue()
         self._pending = aio.Queue()
         self.finished_time = None
-        self.started_time = time.perf_counter()
+        self.started_time = time.time()
         logger.info("regression starting...")
 
         try:
@@ -196,7 +237,7 @@ class Regression(TestBase):
                 for _ in range(self.run_limit):
                     tg.start_soon(self._runner)
         finally:
-            self.finished_time = time.perf_counter()
+            self.finished_time = time.time()
             self._pause_event.set()
             self._running.clear()
             logger.info(f"regression {self.status.name.lower()}.")
@@ -294,23 +335,145 @@ class Regression(TestBase):
                 self.pending.task_done()
                 semaphore.release()
 
-    def dump_state(self, output_dir: Path) -> None:
-        """Write the regression command results to their respective files."""
+    def assign_output_dir(self, output_dir: Path) -> Path:
+        self.output_dir = output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        for child in self.tests:
+            child_output_dir = output_dir / _safe_dir_name(
+                child.name, child.id
+            )
+            if isinstance(child, Regression):
+                child.assign_output_dir(child_output_dir)
+            else:
+                child.output_dir = child_output_dir
+
+        return output_dir
+
+    def dump_state(self, output_dir: Path | None = None) -> Path:
+        """Write the regression state and test artifacts to disk."""
+        root_output_dir = self.output_dir
+        if output_dir is not None:
+            root_output_dir = self.assign_output_dir(output_dir / self.name)
+
+        if root_output_dir is None:
+            msg = "Regression output directory is not configured."
+            raise ValueError(msg)
+
         logger.info("saving regression state and results to disk...")
-        file = output_dir / self.name / "state.yaml"
-        state = self.model_dump(
-            mode="json",
-            round_trip=True,
-            serialize_as_any=True,
-            include={"result", "status"},
-        )
+        self._persist_test_outputs()
+        file = root_output_dir / "state.yaml"
+        state = self._serialize_state(root_output_dir)
         file.parent.mkdir(parents=True, exist_ok=True)
-        file.touch(exist_ok=False)
         box.DDBox(state).to_yaml(str(file))
-        logger.info(f"state and results saved to: '{output_dir}'.")
+        logger.info(f"state and results saved to: '{file}'.")
+        return file
 
     def _active_tests(self) -> list[TestBase]:
         return [test for test in self.tests if test.id in self._running]
+
+    def iter_leaf_tests(self) -> Iterable[TestBase]:
+        for test in self.tests:
+            if isinstance(test, Regression):
+                yield from test.iter_leaf_tests()
+            else:
+                yield test
+
+    @property
+    def leaf_tests(self) -> list[TestBase]:
+        return list(self.iter_leaf_tests())
+
+    @property
+    def total_test_count(self) -> int:
+        return len(self.leaf_tests)
+
+    @property
+    def completed_test_count(self) -> int:
+        return sum(
+            1
+            for test in self.iter_leaf_tests()
+            if test.status in (TestStatus.Finished, TestStatus.Terminated)
+        )
+
+    @property
+    def progress_ratio(self) -> float:
+        total = self.total_test_count
+        if total == 0:
+            return 0.0
+        return min(1.0, self.completed_test_count / total)
+
+    @property
+    def estimated_remaining_time(self) -> float | None:
+        total = self.total_test_count
+        completed = self.completed_test_count
+        elapsed = self.elapsed_time
+
+        if total == 0 or elapsed is None:
+            return None
+        if completed >= total:
+            return 0.0
+        if completed == 0 or elapsed <= 0:
+            return None
+
+        rate = completed / elapsed
+        if rate <= 0:
+            return None
+
+        return max(0.0, (total - completed) / rate)
+
+    def _persist_test_outputs(self) -> None:
+        for child in self.tests:
+            if isinstance(child, Regression):
+                child._persist_test_outputs()
+                continue
+
+            if (
+                isinstance(child, Test)
+                and child.started_time is not None
+                and child.output_dir is not None
+            ):
+                child._prepare_output_files()
+                child._write_output_files()
+
+    def _serialize_state(self, root_output_dir: Path) -> dict[str, Any]:
+        return self._serialize_node(self, root_output_dir)
+
+    @classmethod
+    def _serialize_node(
+        cls, node: TestBase, root_output_dir: Path
+    ) -> dict[str, Any]:
+        state = {
+            "kind": "regression" if isinstance(node, Regression) else "test",
+            "id": str(node.id),
+            "name": node.name,
+            "started_time": node.started_time,
+            "finished_time": node.finished_time,
+            "status": node.status.name.lower(),
+            "result": node.result.value,
+        }
+
+        if node.output_dir is not None and node.output_dir != root_output_dir:
+            state["output_dir"] = str(
+                node.output_dir.relative_to(root_output_dir)
+            )
+
+        if isinstance(node, Regression):
+            state["tests"] = [
+                cls._serialize_node(child, root_output_dir)
+                for child in node.tests
+            ]
+            return state
+
+        state["exec"] = str(node.exec) if node.exec is not None else None
+        if node.stdout_path is not None and node.stdout_path.exists():
+            state["stdout_path"] = str(
+                node.stdout_path.relative_to(root_output_dir)
+            )
+        if node.stderr_path is not None and node.stderr_path.exists():
+            state["stderr_path"] = str(
+                node.stderr_path.relative_to(root_output_dir)
+            )
+        return state
 
     @classmethod
     @validate_call()
@@ -326,20 +489,29 @@ class Regression(TestBase):
         path = TypeAdapter(FilePath).validate_python(path)
         name = name or path.stem
         test_cls = test_cls or Test
+        data = cls._read_data(path)
+
+        settings.update(Box({name: data}), merge=False)
+        return cls._from_data(name, settings[name], test_cls)
+
+    @staticmethod
+    def _read_data(path: Path) -> Mapping[str, Any]:
+        from box import Box
 
         match path.suffix.lower():
             case ".yml" | ".yaml":
-                data = Box.from_yaml(filename=str(path))
+                return Box.from_yaml(filename=str(path))
             case ".toml":
-                data = Box.from_toml(filename=str(path))
+                return Box.from_toml(filename=str(path))
             case ".json":
-                data = Box.from_json(filename=str(path))
+                return Box.from_json(filename=str(path))
             case _:
                 msg = f"Unsupported file format: '{path.suffix}'"
                 raise ValueError(msg)
 
-        settings.update(Box({name: data}), merge=False)
-        return cls._from_data(name, settings[name], test_cls)
+    @staticmethod
+    def _looks_like_state(data: Mapping[str, Any]) -> bool:
+        return data.get("kind") == "regression" and "tests" in data
 
     @classmethod
     def _from_data(
@@ -365,6 +537,97 @@ class Regression(TestBase):
                 )
             regressions.append(regression)
         return cls(name=name, tests=regressions)
+
+    @classmethod
+    def _from_state_data(
+        cls,
+        data: Mapping[str, Any],
+        output_dir: Path,
+        test_cls: type[TestBase],
+    ) -> Self:
+        node = cls._deserialize_node(
+            data,
+            root_output_dir=output_dir,
+            test_cls=test_cls,
+            parent_output_dir=None,
+        )
+        if not isinstance(node, Regression):
+            msg = "State file must contain a root regression."
+            raise ValueError(msg)
+        return node
+
+    @classmethod
+    def _deserialize_node(
+        cls,
+        data: Mapping[str, Any],
+        root_output_dir: Path,
+        test_cls: type[TestBase],
+        parent_output_dir: Path | None,
+    ) -> TestBase:
+        kind = str(data.get("kind", "")).strip().lower()
+        output_dir = cls._resolve_output_dir(
+            data,
+            root_output_dir=root_output_dir,
+            parent_output_dir=parent_output_dir,
+        )
+
+        if kind == "regression":
+            regression = cls(
+                id=data["id"],
+                name=data["name"],
+                started_time=data.get("started_time"),
+                finished_time=data.get("finished_time"),
+                tests=[],
+            )
+            regression.output_dir = output_dir
+            regression.tests = [
+                cls._deserialize_node(
+                    child,
+                    root_output_dir=root_output_dir,
+                    test_cls=test_cls,
+                    parent_output_dir=regression.output_dir,
+                )
+                for child in data.get("tests", [])
+            ]
+            return regression
+
+        test = test_cls(
+            id=data["id"],
+            name=data["name"],
+            exec=data.get("exec"),
+            started_time=data.get("started_time"),
+            finished_time=data.get("finished_time"),
+        )
+        test.output_dir = output_dir
+        test.status = _coerce_status(data.get("status", TestStatus.Idle))
+        test.result = _coerce_result(data.get("result", TestResult.NA))
+
+        if isinstance(test, Test):
+            for attr, relpath in (
+                ("stdout", data.get("stdout_path")),
+                ("stderr", data.get("stderr_path")),
+            ):
+                if relpath:
+                    file = root_output_dir / str(relpath)
+                    if file.exists():
+                        setattr(test, attr, file.read_text(encoding="utf-8"))
+
+        return test
+
+    @classmethod
+    def _resolve_output_dir(
+        cls,
+        data: Mapping[str, Any],
+        *,
+        root_output_dir: Path,
+        parent_output_dir: Path | None,
+    ) -> Path:
+        relative_output_dir = data.get("output_dir")
+        if relative_output_dir:
+            return root_output_dir / str(relative_output_dir)
+        if parent_output_dir is None:
+            return root_output_dir
+        return parent_output_dir / _safe_dir_name(data["name"], data["id"])
 
 
 TreeNode = Annotated[

--- a/src/socx/regression/regression.py
+++ b/src/socx/regression/regression.py
@@ -3,23 +3,17 @@
 from __future__ import annotations
 
 import asyncio as aio
-import anyio
-import logging
-import re
-import time
 from collections import OrderedDict
-from collections.abc import AsyncGenerator, Iterable, Mapping
+from collections.abc import AsyncGenerator, Iterable
 from pathlib import Path
 from threading import RLock
-from typing import Self, Any, Annotated
+from typing import Self, Any, Annotated, Literal
 
-import box
 from pydantic import (
     Field,
     ConfigDict,
     BaseModel,
     PrivateAttr,
-    TypeAdapter,
     UUID4,
     computed_field,
     validate_call,
@@ -28,37 +22,15 @@ from pydantic import (
 )
 
 from socx.config import settings
-from socx.core.schema import FilePath
 from socx.regression.test import Test, TestBase, TestResult, TestStatus
-
-
-logger = logging.getLogger(__name__)
-
-semaphore = anyio.Semaphore(max(1, settings.regression.max_runs_in_parallel))
-
-
-def _safe_dir_name(name: str, node_id: UUID4) -> str:
-    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-").lower()
-    return f"{slug or 'item'}-{node_id}"
-
-
-def _coerce_status(value: TestStatus | int | str) -> TestStatus:
-    if isinstance(value, TestStatus):
-        return value
-    if isinstance(value, int):
-        return TestStatus(value)
-    return TestStatus[value.strip().lower().title()]
-
-
-def _coerce_result(value: TestResult | str) -> TestResult:
-    if isinstance(value, TestResult):
-        return value
-    return TestResult(value)
+from socx.regression.manager import default_regression_manager
+from socx.regression.serializers import _safe_dir_name
 
 
 class Regression(TestBase):
     """Manage and execute a collection of tests with concurrency control."""
 
+    kind: Literal["regression"] = Field(default="regression")
     test_map: OrderedDict[UUID4, SerializeAsAny[TestBase]] = Field(
         default_factory=OrderedDict, repr=True, title="Test Map"
     )
@@ -98,7 +70,9 @@ class Regression(TestBase):
         test_cls: type[TestBase] | None = None,
         **kwargs: Any,
     ) -> Self:
-        return cls._from_file(path, name=name, test_cls=test_cls, **kwargs)
+        return default_regression_manager.from_file(
+            cls, path, name=name, test_cls=test_cls, **kwargs
+        )
 
     @classmethod
     @validate_call()
@@ -109,17 +83,9 @@ class Regression(TestBase):
         test_cls: type[TestBase] | None = None,
         **kwargs: Any,
     ) -> Self:
-        path = TypeAdapter(FilePath).validate_python(path)
-        data = cls._read_data(path)
-
-        if cls._looks_like_state(data):
-            return cls._from_state_data(
-                data,
-                output_dir=path.parent,
-                test_cls=test_cls or Test,
-            )
-
-        return cls._from_file(path, name=name, test_cls=test_cls, **kwargs)
+        return default_regression_manager.load(
+            cls, path, name=name, test_cls=test_cls, **kwargs
+        )
 
     @computed_field
     @property
@@ -213,89 +179,33 @@ class Regression(TestBase):
         """Return ``True`` if ``test`` is tracked by this regression."""
         return test is not None and test.id in self.test_map
 
-    async def start(self) -> None:
+    async def start(self, runner=None) -> None:
         """Start or resume a regression."""
-        if self.status is TestStatus.Paused:
-            await self.resume()
-            return
-
-        if self.started:
-            return
-
-        self._stop_requested = False
-        self._pause_event.set()
-        self._running.clear()
-        self._done = aio.Queue()
-        self._pending = aio.Queue()
-        self.finished_time = None
-        self.started_time = time.time()
-        logger.info("regression starting...")
-
-        try:
-            await self._queue_tests()
-            async with anyio.create_task_group() as tg:
-                for _ in range(self.run_limit):
-                    tg.start_soon(self._runner)
-        finally:
-            self.finished_time = time.time()
-            self._pause_event.set()
-            self._running.clear()
-            logger.info(f"regression {self.status.name.lower()}.")
+        await default_regression_manager.start(self, runner=runner)
 
     async def pause(self) -> None:
         """Pause a running regression and any active descendants."""
-        if self.status is not TestStatus.Running:
-            return
-
-        self._pause_event.clear()
-        await aio.gather(
-            *(test.pause() for test in self._active_tests()),
-            return_exceptions=True,
-        )
+        await default_regression_manager.pause(self)
 
     async def resume(self) -> None:
         """Resume a paused regression and any active descendants."""
-        if self.status is not TestStatus.Paused:
-            return
-
-        self._pause_requested = False
-        self._pause_event.set()
-        await aio.gather(
-            *(test.resume() for test in self.tests),
-            return_exceptions=True,
-        )
+        await default_regression_manager.resume(self)
 
     async def stop(self) -> None:
         """Terminate active work within the regression."""
-        if self.status is TestStatus.Terminated:
-            return
-
-        self._stop_requested = True
-        self._pause_event.set()
-        await aio.gather(
-            *(test.stop() for test in self.tests),
-            return_exceptions=True,
-        )
+        await default_regression_manager.stop(self)
 
     async def restart(self) -> None:
         """Terminate, reset, and execute the regression again."""
-        await self.stop()
-        self.reset()
-        await self.start()
+        await default_regression_manager.restart(self)
 
     def reset(self) -> None:
         """Reset the regression and all child tests."""
-        super().reset()
+        default_regression_manager.reset(self)
 
-        for test in self.tests:
-            if hasattr(test, "reset"):
-                test.reset()
-
-        self._done = aio.Queue()
-        self._pending = aio.Queue()
-        self._pause_event = aio.Event()
-        self._running.clear()
-        self._stop_requested = False
+    def soft_reset(self) -> None:
+        """Reset this regression unless it has already passed."""
+        default_regression_manager.soft_reset(self)
 
     @classmethod
     async def desync[T](cls, it: Iterable[T]) -> AsyncGenerator[T]:
@@ -303,37 +213,11 @@ class Regression(TestBase):
             yield item
 
     async def _queue_tests(self) -> None:
-        items = list(self.tests)
+        items = [test for test in self.tests if not test.passed]
         for test in items:
-            if test.status in (TestStatus.Finished, TestStatus.Terminated):
-                test.reset()
             await self.pending.put(test)
         for _ in range(self.run_limit):
             await self.pending.put(None)
-
-    async def _runner(self) -> None:
-        """Consume queued tests and execute them sequentially."""
-        while True:
-            await semaphore.acquire()
-            test = await self.pending.get()
-            try:
-                if test is None:
-                    return
-
-                while not self._pause_event.is_set():
-                    await aio.sleep(0.05)
-
-                if self._stop_requested:
-                    return
-
-                self._running.add(test.id)
-                await test.start()
-                await self.done.put(test)
-            finally:
-                if test is not None:
-                    self._running.discard(test.id)
-                self.pending.task_done()
-                semaphore.release()
 
     def assign_output_dir(self, output_dir: Path) -> Path:
         self.output_dir = output_dir
@@ -352,22 +236,7 @@ class Regression(TestBase):
 
     def dump_state(self, output_dir: Path | None = None) -> Path:
         """Write the regression state and test artifacts to disk."""
-        root_output_dir = self.output_dir
-        if output_dir is not None:
-            root_output_dir = self.assign_output_dir(output_dir / self.name)
-
-        if root_output_dir is None:
-            msg = "Regression output directory is not configured."
-            raise ValueError(msg)
-
-        logger.info("saving regression state and results to disk...")
-        self._persist_test_outputs()
-        file = root_output_dir / "state.yaml"
-        state = self._serialize_state(root_output_dir)
-        file.parent.mkdir(parents=True, exist_ok=True)
-        box.DDBox(state).to_yaml(str(file))
-        logger.info(f"state and results saved to: '{file}'.")
-        return file
+        return default_regression_manager.dump_state(self, output_dir=output_dir)
 
     def _active_tests(self) -> list[TestBase]:
         return [test for test in self.tests if test.id in self._running]
@@ -434,201 +303,6 @@ class Regression(TestBase):
             ):
                 child._prepare_output_files()
                 child._write_output_files()
-
-    def _serialize_state(self, root_output_dir: Path) -> dict[str, Any]:
-        return self._serialize_node(self, root_output_dir)
-
-    @classmethod
-    def _serialize_node(
-        cls, node: TestBase, root_output_dir: Path
-    ) -> dict[str, Any]:
-        state = {
-            "kind": "regression" if isinstance(node, Regression) else "test",
-            "id": str(node.id),
-            "name": node.name,
-            "started_time": node.started_time,
-            "finished_time": node.finished_time,
-            "status": node.status.name.lower(),
-            "result": node.result.value,
-        }
-
-        if node.output_dir is not None and node.output_dir != root_output_dir:
-            state["output_dir"] = str(
-                node.output_dir.relative_to(root_output_dir)
-            )
-
-        if isinstance(node, Regression):
-            state["tests"] = [
-                cls._serialize_node(child, root_output_dir)
-                for child in node.tests
-            ]
-            return state
-
-        state["exec"] = str(node.exec) if node.exec is not None else None
-        if node.stdout_path is not None and node.stdout_path.exists():
-            state["stdout_path"] = str(
-                node.stdout_path.relative_to(root_output_dir)
-            )
-        if node.stderr_path is not None and node.stderr_path.exists():
-            state["stderr_path"] = str(
-                node.stderr_path.relative_to(root_output_dir)
-            )
-        return state
-
-    @classmethod
-    @validate_call()
-    def _from_file(
-        cls,
-        path: str | Path,
-        name: str | None = None,
-        test_cls: type[TestBase] | None = None,
-    ) -> Self:
-        """Construct a regression from a test configuration file."""
-        from box import Box
-
-        path = TypeAdapter(FilePath).validate_python(path)
-        name = name or path.stem
-        test_cls = test_cls or Test
-        data = cls._read_data(path)
-
-        settings.update(Box({name: data}), merge=False)
-        return cls._from_data(name, settings[name], test_cls)
-
-    @staticmethod
-    def _read_data(path: Path) -> Mapping[str, Any]:
-        from box import Box
-
-        match path.suffix.lower():
-            case ".yml" | ".yaml":
-                return Box.from_yaml(filename=str(path))
-            case ".toml":
-                return Box.from_toml(filename=str(path))
-            case ".json":
-                return Box.from_json(filename=str(path))
-            case _:
-                msg = f"Unsupported file format: '{path.suffix}'"
-                raise ValueError(msg)
-
-    @staticmethod
-    def _looks_like_state(data: Mapping[str, Any]) -> bool:
-        return data.get("kind") == "regression" and "tests" in data
-
-    @classmethod
-    def _from_data(
-        cls,
-        name: str,
-        data: dict[str, Any],
-        test_cls: type[TestBase],
-    ) -> Self:
-        regressions = []
-        for child_name, entries in data.items():
-            if isinstance(entries, list):
-                regression = cls(
-                    name=child_name,
-                    tests=[test_cls(**test) for test in entries],
-                )
-            else:
-                regression = cls(
-                    name=child_name,
-                    tests=[
-                        cls._from_data(key, entries[key], test_cls)
-                        for key in entries
-                    ],
-                )
-            regressions.append(regression)
-        return cls(name=name, tests=regressions)
-
-    @classmethod
-    def _from_state_data(
-        cls,
-        data: Mapping[str, Any],
-        output_dir: Path,
-        test_cls: type[TestBase],
-    ) -> Self:
-        node = cls._deserialize_node(
-            data,
-            root_output_dir=output_dir,
-            test_cls=test_cls,
-            parent_output_dir=None,
-        )
-        if not isinstance(node, Regression):
-            msg = "State file must contain a root regression."
-            raise ValueError(msg)
-        return node
-
-    @classmethod
-    def _deserialize_node(
-        cls,
-        data: Mapping[str, Any],
-        root_output_dir: Path,
-        test_cls: type[TestBase],
-        parent_output_dir: Path | None,
-    ) -> TestBase:
-        kind = str(data.get("kind", "")).strip().lower()
-        output_dir = cls._resolve_output_dir(
-            data,
-            root_output_dir=root_output_dir,
-            parent_output_dir=parent_output_dir,
-        )
-
-        if kind == "regression":
-            regression = cls(
-                id=data["id"],
-                name=data["name"],
-                started_time=data.get("started_time"),
-                finished_time=data.get("finished_time"),
-                tests=[],
-            )
-            regression.output_dir = output_dir
-            regression.tests = [
-                cls._deserialize_node(
-                    child,
-                    root_output_dir=root_output_dir,
-                    test_cls=test_cls,
-                    parent_output_dir=regression.output_dir,
-                )
-                for child in data.get("tests", [])
-            ]
-            return regression
-
-        test = test_cls(
-            id=data["id"],
-            name=data["name"],
-            exec=data.get("exec"),
-            started_time=data.get("started_time"),
-            finished_time=data.get("finished_time"),
-        )
-        test.output_dir = output_dir
-        test.status = _coerce_status(data.get("status", TestStatus.Idle))
-        test.result = _coerce_result(data.get("result", TestResult.NA))
-
-        if isinstance(test, Test):
-            for attr, relpath in (
-                ("stdout", data.get("stdout_path")),
-                ("stderr", data.get("stderr_path")),
-            ):
-                if relpath:
-                    file = root_output_dir / str(relpath)
-                    if file.exists():
-                        setattr(test, attr, file.read_text(encoding="utf-8"))
-
-        return test
-
-    @classmethod
-    def _resolve_output_dir(
-        cls,
-        data: Mapping[str, Any],
-        *,
-        root_output_dir: Path,
-        parent_output_dir: Path | None,
-    ) -> Path:
-        relative_output_dir = data.get("output_dir")
-        if relative_output_dir:
-            return root_output_dir / str(relative_output_dir)
-        if parent_output_dir is None:
-            return root_output_dir
-        return parent_output_dir / _safe_dir_name(data["name"], data["id"])
-
 
 TreeNode = Annotated[
     TestBase,

--- a/src/socx/regression/runners.py
+++ b/src/socx/regression/runners.py
@@ -122,7 +122,8 @@ class DefaultRegressionRunner(RegressionRunner):
                     return
 
                 regression._running.add(test.id)
-                await test.start()
+                runner = getattr(self, "test_runner", default_test_runner)
+                await test.start(runner=runner)
                 await regression.done.put(test)
             finally:
                 if test is not None:

--- a/src/socx/regression/runners.py
+++ b/src/socx/regression/runners.py
@@ -1,0 +1,135 @@
+"""Runner strategies used by test and regression models."""
+
+from __future__ import annotations
+
+import asyncio as aio
+import time
+import logging
+
+import anyio
+
+from socx.config import settings
+from socx.regression.test import TestBase, Test, TestResult, TestStatus
+
+
+logger = logging.getLogger(__name__)
+
+semaphore = anyio.Semaphore(max(1, settings.regression.max_runs_in_parallel))
+
+
+class TestRunner:
+    """Interface for executing a single test node."""
+
+    async def run(self, test: TestBase) -> None:
+        raise NotImplementedError
+
+
+class RegressionRunner:
+    """Interface for executing a regression node."""
+
+    async def run(self, regression) -> None:
+        raise NotImplementedError
+
+
+class DefaultTestRunner(TestRunner):
+    """Subprocess-backed implementation for executing ``Test`` models."""
+
+    async def run(self, test: TestBase) -> None:
+        if not isinstance(test, Test):
+            msg = f"Unsupported test type: {type(test).__name__}"
+            raise TypeError(msg)
+
+        if test.is_running():
+            return
+
+        if test.is_suspended():
+            await test.resume()
+            return
+
+        test._termination_requested = False
+        test.result = TestResult.NA
+        test.stdout = ""
+        test.stderr = ""
+        test.started_time = time.time()
+        test.finished_time = None
+        test.status = TestStatus.Pending
+        test._prepare_output_files()
+
+        if not test.exec:
+            test.status = TestStatus.Terminated
+            test.result = TestResult.Failed
+            test.finished_time = time.time()
+            test._write_output_files()
+            return
+
+        process = await aio.create_subprocess_exec(
+            "/bin/sh",
+            "-c",
+            str(test.exec),
+            stdout=aio.subprocess.PIPE,
+            stderr=aio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        test._process = process
+        test.status = TestStatus.Running
+
+        stdout, stderr = None, None
+
+        try:
+            stdout, stderr = await process.communicate()
+        finally:
+            test.finished_time = time.time()
+            test.stderr = stderr.decode() if stderr else ""
+            test.stdout = stdout.decode() if stdout else ""
+            test._write_output_files()
+            returncode = process.returncode or 0
+
+            if test._termination_requested or returncode < 0:
+                test.status = TestStatus.Terminated
+                test.result = TestResult.Failed
+            elif returncode == 0:
+                test.status = TestStatus.Finished
+                test.result = TestResult.Passed
+            else:
+                test.status = TestStatus.Finished
+                test.result = TestResult.Failed
+
+            test._process = None
+
+
+class DefaultRegressionRunner(RegressionRunner):
+    """Default concurrent runner implementation for regressions."""
+
+    async def run(self, regression) -> None:
+        logger.info("regression starting...")
+        await regression._queue_tests()
+        async with anyio.create_task_group() as tg:
+            for _ in range(regression.run_limit):
+                tg.start_soon(self._worker, regression)
+
+    async def _worker(self, regression) -> None:
+        while True:
+            await semaphore.acquire()
+            test = await regression.pending.get()
+            try:
+                if test is None:
+                    return
+
+                while not regression._pause_event.is_set():
+                    await aio.sleep(0.05)
+
+                if regression._stop_requested:
+                    return
+
+                regression._running.add(test.id)
+                await test.start()
+                await regression.done.put(test)
+            finally:
+                if test is not None:
+                    regression._running.discard(test.id)
+                regression.pending.task_done()
+                semaphore.release()
+
+
+default_test_runner = DefaultTestRunner()
+default_regression_runner = DefaultRegressionRunner()

--- a/src/socx/regression/serializers.py
+++ b/src/socx/regression/serializers.py
@@ -256,14 +256,23 @@ class YamlRegressionSerializer(RegressionSerializer):
         test.result = _coerce_result(data.get("result", TestResult.NA))
 
         if isinstance(test, Test):
+            root_output_dir_resolved = root_output_dir.resolve()
             for attr, relpath in (
                 ("stdout", stdout_relpath),
                 ("stderr", stderr_relpath),
             ):
                 if relpath:
-                    file = root_output_dir / str(relpath)
-                    if file.exists():
-                        setattr(test, attr, file.read_text(encoding="utf-8"))
+                    candidate = (root_output_dir / str(relpath)).resolve()
+                    try:
+                        candidate.relative_to(root_output_dir_resolved)
+                    except ValueError:
+                        continue
+                    if candidate.exists():
+                        setattr(
+                            test,
+                            attr,
+                            candidate.read_text(encoding="utf-8"),
+                        )
 
         return test
 

--- a/src/socx/regression/serializers.py
+++ b/src/socx/regression/serializers.py
@@ -1,0 +1,285 @@
+"""Serialization strategies for regression definitions and runtime state."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import box
+from pydantic import UUID4
+
+from socx.config import settings
+from socx.core.schema import FilePath
+from socx.regression.test import Test, TestBase, TestResult, TestStatus
+
+
+def _safe_dir_name(name: str, node_id: UUID4) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-").lower()
+    return f"{slug or 'item'}-{node_id}"
+
+
+def _coerce_status(value: TestStatus | int | str) -> TestStatus:
+    if isinstance(value, TestStatus):
+        return value
+    if isinstance(value, int):
+        return TestStatus(value)
+    return TestStatus[value.strip().lower().title()]
+
+
+def _coerce_result(value: TestResult | str) -> TestResult:
+    if isinstance(value, TestResult):
+        return value
+    return TestResult(value)
+
+
+class RegressionSerializer:
+    def read_data(self, path: str | Path) -> Mapping[str, Any]:
+        raise NotImplementedError
+
+    def from_file(
+        self,
+        cls,
+        path: str | Path,
+        name: str | None = None,
+        test_cls: type[TestBase] | None = None,
+    ):
+        raise NotImplementedError
+
+    def load(
+        self,
+        cls,
+        path: str | Path,
+        name: str | None = None,
+        test_cls: type[TestBase] | None = None,
+    ):
+        raise NotImplementedError
+
+    def dump_state(self, regression, output_dir: Path | None = None) -> Path:
+        raise NotImplementedError
+
+
+class YamlRegressionSerializer(RegressionSerializer):
+    def from_file(
+        self,
+        cls,
+        path: str | Path,
+        name: str | None = None,
+        test_cls: type[TestBase] | None = None,
+    ):
+        from box import Box
+
+        path = Path(FilePath(path))
+        name = name or path.stem
+        node_cls = test_cls or Test
+        data = self.read_data(path)
+
+        settings.update(Box({name: data}), merge=False)
+        return self._from_data(cls, name, settings[name], node_cls)
+
+    def load(
+        self,
+        cls,
+        path: str | Path,
+        name: str | None = None,
+        test_cls: type[TestBase] | None = None,
+    ):
+        path = Path(FilePath(path))
+        data = self.read_data(path)
+
+        if self._looks_like_state(data):
+            return self._from_state_data(
+                cls,
+                data,
+                output_dir=path.parent,
+                test_cls=test_cls or Test,
+            )
+
+        return self.from_file(cls, path, name=name, test_cls=test_cls)
+
+    def dump_state(self, regression, output_dir: Path | None = None) -> Path:
+        root_output_dir = regression.output_dir
+        if output_dir is not None:
+            root_output_dir = regression.assign_output_dir(
+                output_dir / regression.name
+            )
+
+        if root_output_dir is None:
+            msg = "Regression output directory is not configured."
+            raise ValueError(msg)
+
+        regression._persist_test_outputs()
+        file = root_output_dir / "state.yaml"
+        state = self._serialize_node(regression, root_output_dir)
+        file.parent.mkdir(parents=True, exist_ok=True)
+        box.DDBox(state).to_yaml(str(file))
+        return file
+
+    def read_data(self, path: str | Path) -> Mapping[str, Any]:
+        from box import Box
+
+        path = Path(path)
+        suffix = path.suffix.lower()
+        if suffix in {".yml", ".yaml"}:
+            return Box.from_yaml(filename=str(path))
+        if suffix == ".toml":
+            return Box.from_toml(filename=str(path))
+        if suffix == ".json":
+            return Box.from_json(filename=str(path))
+
+        msg = f"Unsupported file format: '{path.suffix}'"
+        raise ValueError(msg)
+
+    def _looks_like_state(self, data: Mapping[str, Any]) -> bool:
+        return data.get("kind") == "regression" and "tests" in data
+
+    def _from_data(
+        self,
+        cls,
+        name: str,
+        data: dict[str, Any],
+        test_cls: type[TestBase],
+    ):
+        regressions = []
+        for child_name, entries in data.items():
+            if isinstance(entries, list):
+                tests = [test_cls.model_validate(test) for test in entries]
+                regression = cls(name=child_name, tests=tests)
+            else:
+                regression = cls(
+                    name=child_name,
+                    tests=[
+                        self._from_data(cls, key, entries[key], test_cls)
+                        for key in entries
+                    ],
+                )
+            regressions.append(regression)
+        return cls(name=name, tests=regressions)
+
+    def _from_state_data(
+        self,
+        cls,
+        data: Mapping[str, Any],
+        output_dir: Path,
+        test_cls: type[TestBase],
+    ):
+        node = self._deserialize_node(
+            cls,
+            data,
+            root_output_dir=output_dir,
+            test_cls=test_cls,
+            parent_output_dir=None,
+        )
+        if node.kind != "regression":
+            msg = "State file must contain a root regression."
+            raise ValueError(msg)
+        return node
+
+    def _serialize_node(
+        self, node: TestBase, root_output_dir: Path
+    ) -> dict[str, Any]:
+        from socx.regression.regression import Regression
+
+        state = json.loads(
+            node.model_dump_json(serialize_as_any=True)
+        )
+
+        if node.output_dir is not None and node.output_dir != root_output_dir:
+            state["output_dir"] = str(
+                node.output_dir.relative_to(root_output_dir)
+            )
+
+        if isinstance(node, Regression):
+            state["tests"] = [
+                self._serialize_node(child, root_output_dir)
+                for child in node.tests
+            ]
+            return state
+
+        state.pop("stdout", None)
+        state.pop("stderr", None)
+        if node.stdout_path is not None and node.stdout_path.exists():
+            state["stdout_path"] = str(
+                node.stdout_path.relative_to(root_output_dir)
+            )
+        if node.stderr_path is not None and node.stderr_path.exists():
+            state["stderr_path"] = str(
+                node.stderr_path.relative_to(root_output_dir)
+            )
+        return state
+
+    def _deserialize_node(
+        self,
+        cls,
+        data: Mapping[str, Any],
+        root_output_dir: Path,
+        test_cls: type[TestBase],
+        parent_output_dir: Path | None,
+    ):
+        kind = str(data.get("kind", "")).strip().lower()
+        output_dir = self._resolve_output_dir(
+            data,
+            root_output_dir=root_output_dir,
+            parent_output_dir=parent_output_dir,
+        )
+
+        node_data = dict(data)
+        node_data.pop("output_dir", None)
+
+        if kind == "regression":
+            tests_data = node_data.pop("tests", [])
+            regression = cls.model_validate(node_data)
+            regression.output_dir = output_dir
+            regression.tests = [
+                self._deserialize_node(
+                    cls,
+                    child,
+                    root_output_dir=root_output_dir,
+                    test_cls=test_cls,
+                    parent_output_dir=regression.output_dir,
+                )
+                for child in tests_data
+            ]
+            return regression
+
+        if kind != "test":
+            msg = f"Unknown state node kind: '{kind}'"
+            raise ValueError(msg)
+
+        stdout_relpath = node_data.pop("stdout_path", None)
+        stderr_relpath = node_data.pop("stderr_path", None)
+        test = test_cls.model_validate(node_data)
+        test.output_dir = output_dir
+        test.status = _coerce_status(data.get("status", TestStatus.Idle))
+        test.result = _coerce_result(data.get("result", TestResult.NA))
+
+        if isinstance(test, Test):
+            for attr, relpath in (
+                ("stdout", stdout_relpath),
+                ("stderr", stderr_relpath),
+            ):
+                if relpath:
+                    file = root_output_dir / str(relpath)
+                    if file.exists():
+                        setattr(test, attr, file.read_text(encoding="utf-8"))
+
+        return test
+
+    def _resolve_output_dir(
+        self,
+        data: Mapping[str, Any],
+        *,
+        root_output_dir: Path,
+        parent_output_dir: Path | None,
+    ) -> Path:
+        relative_output_dir = data.get("output_dir")
+        if relative_output_dir:
+            return root_output_dir / str(relative_output_dir)
+        if parent_output_dir is None:
+            return root_output_dir
+        return parent_output_dir / _safe_dir_name(data["name"], data["id"])
+
+
+default_regression_serializer = YamlRegressionSerializer()

--- a/src/socx/regression/serializers.py
+++ b/src/socx/regression/serializers.py
@@ -283,9 +283,18 @@ class YamlRegressionSerializer(RegressionSerializer):
         root_output_dir: Path,
         parent_output_dir: Path | None,
     ) -> Path:
+        # Ensure we are working with normalized absolute paths
+        root_output_dir = root_output_dir.resolve()
         relative_output_dir = data.get("output_dir")
         if relative_output_dir:
-            return root_output_dir / str(relative_output_dir)
+            # Join and normalize the path, then verify it is within root_output_dir
+            candidate = (root_output_dir / str(relative_output_dir)).resolve()
+            try:
+                candidate.relative_to(root_output_dir)
+            except ValueError as exc:
+                msg = "Invalid output_dir in state file: must be within root_output_dir"
+                raise ValueError(msg) from exc
+            return candidate
         if parent_output_dir is None:
             return root_output_dir
         return parent_output_dir / _safe_dir_name(data["name"], data["id"])

--- a/src/socx/regression/test.py
+++ b/src/socx/regression/test.py
@@ -9,6 +9,7 @@ import time
 import uuid
 from enum import StrEnum, IntEnum, auto
 from pathlib import Path
+from typing import Literal
 
 from pydantic import (
     BaseModel,
@@ -50,6 +51,7 @@ class TestBase(BaseModel):
     name: str = Field(...)
     started_time: float | None = Field(None)
     finished_time: float | None = Field(None)
+    kind: Literal["test"] = Field(default="test")
 
     model_config = ConfigDict(
         from_attributes=True,
@@ -171,7 +173,7 @@ class TestBase(BaseModel):
         os.killpg(self._process.pid, signal.SIGSTOP)
         self.status = TestStatus.Paused
 
-    async def start(self) -> None:
+    async def start(self, runner=None) -> None:
         """Execute the test executable to start the test."""
         raise NotImplementedError()
 
@@ -212,6 +214,13 @@ class TestBase(BaseModel):
         self._status = TestStatus.Idle
         self._process = None
         self._termination_requested = False
+
+
+    def soft_reset(self) -> None:
+        """Reset this test unless it has already passed."""
+        if self.passed:
+            return
+        self.reset()
 
     async def restart(self) -> None:
         """Terminate, reset, and execute the test again."""
@@ -264,64 +273,13 @@ class Test(TestBase):
         self._stdout = ""
         self._stderr = ""
 
-    async def start(self) -> None:
-        """Execute the test executable to start the test."""
-        if self.is_running():
-            return
+    async def start(self, runner=None) -> None:
+        """Execute this test using an injected or default runner."""
+        if runner is None:
+            from socx.regression.runners import default_test_runner
 
-        if self.is_suspended():
-            await self.resume()
-            return
-
-        self._termination_requested = False
-        self.result = TestResult.NA
-        self.stdout = ""
-        self.stderr = ""
-        self.started_time = time.time()
-        self.finished_time = None
-        self.status = TestStatus.Pending
-        self._prepare_output_files()
-
-        if not self.exec:
-            self.status = TestStatus.Terminated
-            self.result = TestResult.Failed
-            self.finished_time = time.time()
-            self._write_output_files()
-            return
-
-        process = await aio.create_subprocess_exec(
-            "/bin/sh",
-            "-c",
-            str(self.exec),
-            stdout=aio.subprocess.PIPE,
-            stderr=aio.subprocess.PIPE,
-            start_new_session=True,
-        )
-        self._process = process
-        self.status = TestStatus.Running
-
-        stdout, stderr = None, None
-
-        try:
-            stdout, stderr = await process.communicate()
-        finally:
-            self.finished_time = time.time()
-            self.stderr = stderr.decode() if stderr else ""
-            self.stdout = stdout.decode() if stdout else ""
-            self._write_output_files()
-            returncode = process.returncode or 0
-
-            if self._termination_requested or returncode < 0:
-                self.status = TestStatus.Terminated
-                self.result = TestResult.Failed
-            elif returncode == 0:
-                self.status = TestStatus.Finished
-                self.result = TestResult.Passed
-            else:
-                self.status = TestStatus.Finished
-                self.result = TestResult.Failed
-
-            self._process = None
+            runner = default_test_runner
+        await runner.run(self)
 
     def _write_output_files(self) -> None:
         for path, content in (

--- a/src/socx/regression/test.py
+++ b/src/socx/regression/test.py
@@ -8,6 +8,7 @@ import signal
 import time
 import uuid
 from enum import StrEnum, IntEnum, auto
+from pathlib import Path
 
 from pydantic import (
     BaseModel,
@@ -59,6 +60,7 @@ class TestBase(BaseModel):
     _status: TestStatus = PrivateAttr(TestStatus.Idle)
     _process: aio.subprocess.Process | None = PrivateAttr(default=None)
     _termination_requested: bool = PrivateAttr(default=False)
+    _output_dir: Path | None = PrivateAttr(default=None)
 
     @computed_field
     @property
@@ -84,11 +86,40 @@ class TestBase(BaseModel):
             return None
         return Process(self._process.pid)
 
+    @property
+    def output_dir(self) -> Path | None:
+        return self._output_dir
+
+    @output_dir.setter
+    def output_dir(self, value: Path | None) -> None:
+        self._output_dir = value
+
+    @property
+    def stdout_path(self) -> Path | None:
+        if self.output_dir is None:
+            return None
+        return self.output_dir / "stdout.txt"
+
+    @property
+    def stderr_path(self) -> Path | None:
+        if self.output_dir is None:
+            return None
+        return self.output_dir / "stderr.txt"
+
     @computed_field
     @property
     def started(self) -> bool:
         """Return ``True`` once ``start`` has spawned the subprocess."""
         return self.status > TestStatus.Pending
+
+    @property
+    def elapsed_time(self) -> float | None:
+        """Return the elapsed runtime derived from wall-clock timestamps."""
+        if self.started_time is None:
+            return None
+
+        end_time = self.finished_time or time.time()
+        return max(0.0, end_time - self.started_time)
 
     @property
     def finished(self) -> bool:
@@ -188,6 +219,15 @@ class TestBase(BaseModel):
         self.reset()
         await self.start()
 
+    def _prepare_output_files(self) -> None:
+        if self.output_dir is None:
+            return
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        for path in (self.stdout_path, self.stderr_path):
+            if path is not None:
+                path.write_text("", encoding="utf-8")
+
 
 class Test(TestBase):
     """Concrete test model with subprocess execution support."""
@@ -237,14 +277,16 @@ class Test(TestBase):
         self.result = TestResult.NA
         self.stdout = ""
         self.stderr = ""
-        self.started_time = time.perf_counter()
+        self.started_time = time.time()
         self.finished_time = None
         self.status = TestStatus.Pending
+        self._prepare_output_files()
 
         if not self.exec:
             self.status = TestStatus.Terminated
             self.result = TestResult.Failed
-            self.finished_time = time.perf_counter()
+            self.finished_time = time.time()
+            self._write_output_files()
             return
 
         process = await aio.create_subprocess_exec(
@@ -263,9 +305,10 @@ class Test(TestBase):
         try:
             stdout, stderr = await process.communicate()
         finally:
-            self.finished_time = time.perf_counter()
+            self.finished_time = time.time()
             self.stderr = stderr.decode() if stderr else ""
             self.stdout = stdout.decode() if stdout else ""
+            self._write_output_files()
             returncode = process.returncode or 0
 
             if self._termination_requested or returncode < 0:
@@ -279,3 +322,11 @@ class Test(TestBase):
                 self.result = TestResult.Failed
 
             self._process = None
+
+    def _write_output_files(self) -> None:
+        for path, content in (
+            (self.stdout_path, self.stdout),
+            (self.stderr_path, self.stderr),
+        ):
+            if path is not None:
+                path.write_text(content, encoding="utf-8")

--- a/src/socx_plugins/regression/_run.py
+++ b/src/socx_plugins/regression/_run.py
@@ -219,6 +219,7 @@ async def run_regression(
     path_in = file or _get_input_path()
     regression = populate_regression(path_in)
     output_dir = _get_output_path(regression)
+    regression.assign_output_dir(output_dir / regression.name)
     names_set = _get_names_to_run()
     progress = RegressionProgress(regression)
 

--- a/src/socx_tui/regression/app.py
+++ b/src/socx_tui/regression/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import Any, ClassVar
 from collections import ChainMap
 from collections.abc import Iterable
@@ -37,6 +38,16 @@ class SoCX(App[int]):
     def run(self, *args: Any, **kwargs: Any) -> int | None:
         kwargs = dict(ChainMap(kwargs, dict(inline=True)))
         return super().run(*args, **kwargs)
+
+    def exit(
+        self,
+        result: int | None = None,
+        return_code: int = 0,
+        message: Any | None = None,
+    ) -> None:
+        with suppress(Exception):
+            self.regression.persist_loaded_regression_state()
+        super().exit(result=result, return_code=return_code, message=message)
 
     def compose(self) -> ComposeResult:
         """Lay out the application chrome shared between all screens."""

--- a/src/socx_tui/regression/details.py
+++ b/src/socx_tui/regression/details.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from textwrap import wrap
 from typing import ClassVar
 
@@ -79,9 +80,11 @@ class RegressionDetails(Widget, can_focus=True, inherit_bindings=True):
                     f"**✅ Passed:** {self.count_results(model, TestResult.Passed)}",  # noqa: E501
                     f"**💡 Status:** {self.format_status(model.status)}",
                     f"**🚩 Result:** {self.format_result(model.result)}",
-                    # f"**⌛ Elapsed Time:** {self.format_timedelta(model.time_elapsed)}",  # noqa: E501, W505
+                    f"**⌛ Elapsed Time:** {self.format_timedelta(model.elapsed_time)}",  # noqa: E501
                     f"**⌛ Started Time:** {self.format_time(model.started_time)}",  # noqa: E501
                     f"**⌛ Finished Time:** {self.format_time(model.finished_time)}",  # noqa: E501
+                    f"**📊 Progress:** `{self.format_progress(model)}`",
+                    f"**⏳ ETA:** {self.format_timedelta(model.estimated_remaining_time)}",  # noqa: E501
                 ]
             )
         else:
@@ -89,7 +92,7 @@ class RegressionDetails(Widget, can_focus=True, inherit_bindings=True):
                 [
                     f"**💡 Status:** {self.format_status(model.status)}",
                     f"**🚩 Result:** {self.format_result(model.result)}",
-                    # f"**⌛ Elapsed Time:** {self.format_timedelta(model.time_elapsed)}",  # noqa: E501, W505
+                    f"**⌛ Elapsed Time:** {self.format_timedelta(model.elapsed_time)}",  # noqa: E501
                     f"**⌛ Started Time:** {self.format_time(model.started_time)}",  # noqa: E501
                     f"**⌛ Finished Time:** {self.format_time(model.finished_time)}",  # noqa: E501
                     "",
@@ -123,7 +126,20 @@ class RegressionDetails(Widget, can_focus=True, inherit_bindings=True):
         return status.name.lower()
 
     def format_time(self, value: float | None) -> str:
-        return "n/a" if value is None else f"{value:.3f}"
+        if value is None:
+            return "n/a"
+
+        try:
+            if value >= 946684800:
+                return (
+                    datetime.fromtimestamp(value)
+                    .astimezone()
+                    .strftime("%Y-%m-%d %H:%M:%S %Z")
+                )
+        except (OverflowError, OSError, ValueError):
+            pass
+
+        return f"{value:.3f}s"
 
     def format_timedelta(self, value: int | float | None) -> str:
         if value is None:
@@ -135,4 +151,15 @@ class RegressionDetails(Widget, can_focus=True, inherit_bindings=True):
         return f"{hours:02}h:{minutes:02}m:{seconds:02}s"
 
     def count_results(self, regression: Regression, result: TestResult) -> int:
-        return sum(1 for test in regression.tests if test.result is result)
+        return sum(
+            1 for test in regression.iter_leaf_tests() if test.result is result
+        )
+
+    def format_progress(self, regression: Regression, width: int = 24) -> str:
+        total = regression.total_test_count
+        completed = regression.completed_test_count
+        ratio = regression.progress_ratio
+        filled = min(width, round(ratio * width))
+        bar = "#" * filled + "-" * (width - filled)
+        percent = int(ratio * 100)
+        return f"[{bar}] {completed}/{total} ({percent}%)"

--- a/src/socx_tui/regression/dialog.py
+++ b/src/socx_tui/regression/dialog.py
@@ -9,6 +9,7 @@ from textual.binding import Binding, BindingType
 from textual.containers import Vertical
 from textual.screen import ModalScreen, ScreenResultType
 from textual.widgets import Static, TextArea
+from textual.widgets import Button
 
 from socx_tui.regression.bindings.vim.mode import VimModes
 
@@ -104,3 +105,52 @@ class TestOutputDialog(ModalScreen[ScreenResultType]):
                 stderr,
             ]
         )
+
+
+class RestartSelectionDialog(ModalScreen[str | None]):
+    """Modal dialog that asks which tests should be restarted."""
+
+    DEFAULT_CSS: ClassVar[str] = """
+    RestartSelectionDialog {
+        align: center middle;
+    }
+
+    #restart-selection-dialog {
+        width: 72;
+        height: auto;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #restart-selection-actions {
+        height: auto;
+        layout: vertical;
+    }
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "dismiss(None)", show=False),
+        Binding("q", "dismiss(None)", show=False),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Dialog(id="restart-selection-dialog"):
+            yield Static("Restart scope", id="restart-selection-title")
+            with Vertical(id="restart-selection-actions"):
+                yield Button("All tests", id="restart-scope-all")
+                yield Button(
+                    "Failing + cancelled", id="restart-scope-failed-cancelled"
+                )
+                yield Button("Only cancelled", id="restart-scope-cancelled")
+                yield Button("Only failing", id="restart-scope-failed")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id
+        mapping = {
+            "restart-scope-all": "all",
+            "restart-scope-failed-cancelled": "failed_or_cancelled",
+            "restart-scope-cancelled": "cancelled",
+            "restart-scope-failed": "failed",
+        }
+        self.dismiss(mapping.get(button_id))

--- a/src/socx_tui/regression/dialog.py
+++ b/src/socx_tui/regression/dialog.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
-from socx_tui.regression.details import RegressionDetails
-from textual.screen import ModalScreen, ScreenResultType
 
 from typing import ClassVar
 
 import rich.repr
-from socx import TestBase
+from socx import Test
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import (
-    Vertical,
-)
+from textual.containers import Vertical
+from textual.screen import ModalScreen, ScreenResultType
+from textual.widgets import Static, TextArea
+
+from socx_tui.regression.bindings.vim.mode import VimModes
 
 
 class Dialog(Vertical):
@@ -19,33 +19,88 @@ class Dialog(Vertical):
     pass
 
 
+class ReadOnlyOutputArea(TextArea, can_focus=True, inherit_bindings=True):
+    """Read-only output viewer with keyboard navigation."""
+
+    BINDINGS: ClassVar[list[BindingType]] = TextArea.BINDINGS + VimModes.Normal
+
+
 @rich.repr.auto
-class ActionDialog(ModalScreen[ScreenResultType]):
+class TestOutputDialog(ModalScreen[ScreenResultType]):
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding(
             key="escape",
             action="dismiss(None)",
             description="Dismiss the dialog.",
             show=False,
-        )
+        ),
+        Binding(
+            key="q",
+            action="dismiss(None)",
+            description="Dismiss the dialog.",
+            show=False,
+        ),
     ]
 
-    def __init__(self, model: TestBase, *args, **kwargs) -> None:
+    DEFAULT_CSS: ClassVar[str] = """
+    TestOutputDialog {
+        align: center middle;
+    }
+
+    #regression-output-dialog {
+        width: 92%;
+        height: 88%;
+        border: thick $accent;
+        background: $surface;
+    }
+
+    #regression-output-title {
+        padding: 0 1;
+        height: auto;
+        text-style: bold;
+    }
+
+    #regression-output-area {
+        height: 1fr;
+    }
+    """
+
+    def __init__(self, model: Test, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._model = model
-        self._details_view = RegressionDetails(
-            wrap_code=False,
-            id="regression-dialog-details",
-            name="regression-dialog-details",
+        self._output_view = ReadOnlyOutputArea(
+            self._format_output(model),
+            id="regression-output-area",
+            language="bash",
+            read_only=True,
+            soft_wrap=False,
+            show_cursor=True,
+            show_line_numbers=True,
         )
 
     def compose(self) -> ComposeResult:
         with Dialog(
-            id="regression-dialog-content",
-            name="regression-dialog-content",
+            id="regression-output-dialog",
+            name="regression-output-dialog",
         ):
-            yield self._details_view
+            yield Static(
+                f"{self._model.name} stdout / stderr",
+                id="regression-output-title",
+            )
+            yield self._output_view
 
     def on_mount(self) -> None:
-        self._details_view.model = self._model
-        self._details_view.focus()
+        self._output_view.focus()
+
+    def _format_output(self, model: Test) -> str:
+        stdout = model.stdout or "<no stdout captured>"
+        stderr = model.stderr or "<no stderr captured>"
+        return "\n".join(
+            [
+                "===== STDOUT =====",
+                stdout,
+                "",
+                "===== STDERR =====",
+                stderr,
+            ]
+        )

--- a/src/socx_tui/regression/tree.py
+++ b/src/socx_tui/regression/tree.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 import rich.repr
 from textual.binding import BindingType
+from textual.message import Message
 from textual.widgets import Tree
 
 from socx_tui.regression.bindings.vim.mode import VimModes
@@ -14,6 +15,13 @@ from socx_tui.regression.bindings.vim.mode import VimModes
 @rich.repr.auto
 class VimTree(Tree[object], can_focus=True, inherit_bindings=True):
     """Interactive tree widget with Vim-style navigation bindings."""
+
+    class OpenCursorNode(Message):
+        """Posted when Enter is pressed on the current tree node."""
+
+        def __init__(self, node: object) -> None:
+            self.node = node
+            super().__init__()
 
     BINDINGS: ClassVar[list[BindingType]] = Tree.BINDINGS + VimModes.Normal
 
@@ -30,4 +38,6 @@ class VimTree(Tree[object], can_focus=True, inherit_bindings=True):
         node = self.cursor_node
         if node is not None and node.allow_expand:
             node.toggle()
+        if node is not None:
+            self.post_message(self.OpenCursorNode(node))
         super().action_select_cursor()

--- a/src/socx_tui/regression/widget.py
+++ b/src/socx_tui/regression/widget.py
@@ -18,7 +18,7 @@ from textual.widgets import Button, Tree
 from textual_fspicker import FileOpen
 
 from socx_tui.regression.details import RegressionDetails
-from socx_tui.regression.dialog import TestOutputDialog
+from socx_tui.regression.dialog import RestartSelectionDialog, TestOutputDialog
 from socx_tui.regression.tree import VimTree
 
 
@@ -46,7 +46,7 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
         Binding("X", "stop_selected()", "Stop", show=True),
         Binding("p", "pause_selected()", "Pause", show=True),
         Binding("r", "resume_selected()", "Resume", show=True),
-        Binding("R", "restart_selected()", "Restart", show=True),
+        Binding("R", "prompt_restart_selected()", "Restart", show=True),
     ]
     ALLOW_MAXIMIZE: ClassVar[bool] = True
 
@@ -173,7 +173,21 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
         if model is None:
             self._no_model_selected_notification()
             return
-        self._restart_model(model)
+        self._restart_model(model, "all")
+
+    async def action_prompt_restart_selected(self) -> None:
+        model = self.selected_model
+        if model is None:
+            self._no_model_selected_notification()
+            return
+        if not isinstance(model, Regression):
+            self._restart_model(model, "all")
+            return
+
+        self.app.push_screen(
+            RestartSelectionDialog(),
+            callback=lambda scope: self._on_restart_scope_selected(model, scope),
+        )
 
     @on(VimTree.OpenCursorNode)
     async def on_vim_tree_open_cursor_node(
@@ -197,7 +211,15 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
             case "resume-button":
                 self.app.call_next(self.action_resume_selected)
             case "restart-button":
-                self.app.call_next(self.action_restart_selected)
+                self.app.call_next(self.action_prompt_restart_selected)
+
+
+    def _on_restart_scope_selected(
+        self, model: Regression, scope: str | None
+    ) -> None:
+        if scope is None:
+            return
+        self._restart_model(model, scope)
 
     @work(exclusive=False)
     async def load_regression_from_file(self) -> None:
@@ -224,10 +246,37 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
         self._refresh_tree_state()
 
     @work(exclusive=False)
-    async def _restart_model(self, model: TestBase) -> None:
+    async def _restart_model(self, model: TestBase, scope: str = "all") -> None:
         self._set_refresh_timer(True)
-        await model.restart()
+        if isinstance(model, Regression):
+            await self._restart_regression_by_scope(model, scope)
+        else:
+            await model.restart()
         self._refresh_tree_state()
+
+
+    async def _restart_regression_by_scope(
+        self, regression: Regression, scope: str
+    ) -> None:
+        if scope == "all":
+            await regression.restart()
+            return
+
+        if scope == "failed_or_cancelled":
+            selector = lambda t: t.failed or t.terminated
+        elif scope == "cancelled":
+            selector = lambda t: t.terminated
+        elif scope == "failed":
+            selector = lambda t: t.finished and t.result is TestResult.Failed
+        else:
+            selector = lambda t: False
+
+        for test in regression.iter_leaf_tests():
+            if selector(test):
+                test.soft_reset()
+
+        regression.soft_reset()
+        await regression.start()
 
     async def load_regression_from_path(self, path: Path) -> Regression:
         """Load regressions or saved state from ``path`` into the tree."""
@@ -350,8 +399,6 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
             return
 
         self._sync_refresh_timer()
-        if self.app.screen is not self.screen:
-            return
 
         labels_changed = False
         for node in self.node_map.values():

--- a/src/socx_tui/regression/widget.py
+++ b/src/socx_tui/regression/widget.py
@@ -1,26 +1,25 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from pathlib import Path
-from typing import ClassVar, Any
+from typing import Any, ClassVar
 
 import rich.repr
 from rich.text import Text
-from socx import Regression, TestBase, TestResult, TestStatus
-from textual import work, on
+from socx import Regression, Test, TestBase, TestResult, TestStatus, settings
+from textual import on, work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import (
-    Container,
-)
+from textual.containers import Container
 from textual.timer import Timer
 from textual.widget import Widget
 from textual.widgets import Button, Tree
 from textual_fspicker import FileOpen
 
-from socx_tui.regression.tree import VimTree
-from socx_tui.regression.dialog import ActionDialog
 from socx_tui.regression.details import RegressionDetails
+from socx_tui.regression.dialog import TestOutputDialog
+from socx_tui.regression.tree import VimTree
 
 
 logger = logging.getLogger(__name__)
@@ -103,12 +102,17 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
             classes="layout",
         )
         self._refresh_timer: Timer | None = None
+        self._refresh_enabled = False
 
     @property
     def selected_model(self) -> TestBase | None:
         node = self.regression_tree.cursor_node
         data = getattr(node, "data", None)
         return data if isinstance(data, TestBase) else None
+
+    @property
+    def refresh_enabled(self) -> bool:
+        return self._refresh_enabled
 
     def compose(self) -> ComposeResult:
         yield self.content
@@ -117,7 +121,7 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
     async def on_mount(self) -> None:
         self.regression_tree.focus()
         self._refresh_timer = self.set_interval(
-            1 / 5, self._refresh_tree_state
+            1 / 5, self._refresh_tree_state, pause=True
         )
 
     def show_text(self, message: str | Text) -> None:
@@ -160,6 +164,7 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
             self._no_model_selected_notification()
             return
         if model.is_suspended():
+            self._set_refresh_timer(True)
             await model.resume()
             self._refresh_tree_state()
 
@@ -170,17 +175,16 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
             return
         self._restart_model(model)
 
-    @work(exclusive=False)
-    @on(Tree.NodeSelected)
-    async def _select_node(self, event: Tree.NodeSelected) -> None:
-        model = self.selected_model
-
-        if model is None:
-            self._no_model_selected_notification()
+    @on(VimTree.OpenCursorNode)
+    async def on_vim_tree_open_cursor_node(
+        self, event: VimTree.OpenCursorNode
+    ) -> None:
+        model = getattr(event.node, "data", None)
+        if not isinstance(model, Test):
             return
 
         event.stop()
-        await self.app.push_screen_wait(ActionDialog(model))
+        self.app.push_screen(TestOutputDialog(model))
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         match event.button.id:
@@ -207,6 +211,7 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
 
     @work(exclusive=False)
     async def _start_model(self, model: TestBase) -> None:
+        self._set_refresh_timer(True)
         if model.is_suspended():
             await model.resume()
         else:
@@ -220,16 +225,31 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
 
     @work(exclusive=False)
     async def _restart_model(self, model: TestBase) -> None:
+        self._set_refresh_timer(True)
         await model.restart()
         self._refresh_tree_state()
 
     async def load_regression_from_path(self, path: Path) -> Regression:
-        """Load regressions from ``path`` into the tree."""
-        regression = Regression.from_file(path=path)
+        """Load regressions or saved state from ``path`` into the tree."""
+        regression = Regression.load(path=path)
+        if regression.output_dir is None:
+            regression.assign_output_dir(
+                self._create_session_output_dir(regression)
+            )
+
         self.loaded_regression = regression
         self._populate_tree(regression)
+        self._refresh_tree_state()
         self.regression_tree.focus()
         return regression
+
+    def persist_loaded_regression_state(self) -> Path | None:
+        if self.loaded_regression is None:
+            return None
+
+        file = self.loaded_regression.dump_state()
+        self.log.info(f"Saved regression state to '{file}'.")
+        return file
 
     async def _load_regression_from_file(self) -> None:
         file = await self._open_file_dialog()
@@ -268,13 +288,8 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
 
     def on_tree_node_selected(self, event: Tree.NodeSelected[object]) -> None:
         model = event.node.data
-        if not isinstance(model, TestBase):
-            return
-
-        if isinstance(model, Regression) and event.node.allow_expand:
-            event.node.toggle()
-
-        self.show_details(model)
+        if isinstance(model, TestBase):
+            self.show_details(model)
 
     def _populate_tree(self, regression: Regression) -> None:
         root = self.regression_tree.root
@@ -290,10 +305,12 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
 
         if first_node is None:
             self.show_details(regression)
+            self._sync_refresh_timer()
             return
 
         self.regression_tree.move_cursor(first_node)
         self.show_details(first_node.data)
+        self._sync_refresh_timer()
 
     def _top_level_regressions(
         self, regression: Regression
@@ -327,9 +344,16 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
         return node
 
     def _refresh_tree_state(self) -> None:
-        if self.loaded_regression is None:
+        regression = self.loaded_regression
+        if regression is None:
+            self._set_refresh_timer(False)
             return
 
+        self._sync_refresh_timer()
+        if self.app.screen is not self.screen:
+            return
+
+        labels_changed = False
         for node in self.node_map.values():
             model = getattr(node, "data", None)
             if not isinstance(model, TestBase):
@@ -340,14 +364,52 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
                 if isinstance(model, Regression)
                 else self._format_test_label(model)
             )
-            node.set_label(label)
+            current_label = getattr(node.label, "plain", str(node.label))
+            if current_label != label.plain:
+                node.set_label(label)
+                labels_changed = True
 
-        self.regression_tree.refresh()
+        if labels_changed:
+            self.regression_tree.refresh()
 
         if self.selected_model != self.details_view.model:
             self.details_view.model = self.selected_model
         else:
             self.details_view.refresh_details()
+
+    def _sync_refresh_timer(self) -> None:
+        regression = self.loaded_regression
+        should_refresh = regression is not None and regression.status in (
+            TestStatus.Pending,
+            TestStatus.Running,
+        )
+        self._set_refresh_timer(should_refresh)
+
+    def _set_refresh_timer(self, enabled: bool) -> None:
+        if self._refresh_timer is None or self._refresh_enabled == enabled:
+            self._refresh_enabled = enabled
+            return
+
+        self._refresh_enabled = enabled
+        if enabled:
+            self._refresh_timer.resume()
+            self._refresh_timer.reset()
+        else:
+            self._refresh_timer.pause()
+
+    def _create_session_output_dir(self, regression: Regression) -> Path:
+        now = datetime.now().astimezone()
+        output_root = settings.regression.run.output.directory
+        base_dir = (
+            Path(output_root) if isinstance(output_root, str) else output_root
+        )
+        return (
+            base_dir
+            / regression.name
+            / now.strftime("%Y-%m-%d")
+            / now.strftime("%H-%M-%S")
+            / regression.name
+        )
 
     def _format_regression_label(self, regression: Regression) -> Text:
         return Text.assemble(
@@ -401,7 +463,6 @@ class RegressionWidget(Widget, can_focus=False, inherit_bindings=True):
     def _format_test_status_label(self, test: TestBase) -> Text:
         status = f"💡 {self.details_view.format_status(test.status)}"
         result = f"🚩 {self.details_view.format_result(test.result)}"
-        # elapsed = f"⌛ {self.details_view.format_timedelta(test.time_elapsed)}"  # noqa: E501, W505
         return Text.assemble("[", "|".join([status, result]), "]")
 
     def _no_model_selected_notification(self) -> None:

--- a/src/socx_tui/static/tcss/regression/app.tcss
+++ b/src/socx_tui/static/tcss/regression/app.tcss
@@ -91,6 +91,7 @@ Button:hover {
 Header {
     width: 100%;
     height: auto;
+    background: $panel;
     padding: 0;
     margin: 0;
 }
@@ -98,6 +99,7 @@ Header {
 Footer {
     width: 100%;
     height: auto;
+    background: $panel;
     padding: 0;
     margin: 0;
 }

--- a/tests/test_regression_runtime.py
+++ b/tests/test_regression_runtime.py
@@ -52,10 +52,63 @@ def test_regression_can_restart_children(tmp_path) -> None:
         await regression.start()
         assert regression.status is TestStatus.Finished
         assert marker.read_text().splitlines() == ["run"]
+        assert regression.elapsed_time is not None
+        assert regression.total_test_count == 1
+        assert regression.completed_test_count == 1
+        assert regression.progress_ratio == 1.0
+        assert regression.estimated_remaining_time == 0.0
 
         await regression.restart()
 
         assert regression.status is TestStatus.Finished
         assert marker.read_text().splitlines() == ["run", "run"]
+
+    asyncio.run(run_test())
+
+
+def test_regression_state_round_trips_with_test_outputs(tmp_path) -> None:
+    async def run_test() -> None:
+        regression = Regression(
+            name="smoke",
+            tests=[
+                Test(
+                    name="alpha",
+                    exec="printf 'alpha out'; printf 'alpha err' >&2",
+                )
+            ],
+        )
+        session_dir = tmp_path / "session"
+        regression.assign_output_dir(session_dir / regression.name)
+        test = regression.tests[0]
+
+        task = asyncio.create_task(regression.start())
+        await _wait_for(
+            lambda: (
+                test.output_dir is not None
+                and test.output_dir.is_dir()
+                and test.stdout_path is not None
+                and test.stdout_path.exists()
+                and test.stderr_path is not None
+                and test.stderr_path.exists()
+            )
+        )
+        await task
+
+        state_file = regression.dump_state(session_dir)
+        loaded = Regression.load(state_file)
+        loaded_test = loaded.tests[0]
+
+        assert regression.started_time is not None
+        assert regression.started_time > 946684800
+        assert state_file.exists()
+        assert isinstance(loaded_test, Test)
+        assert loaded_test.stdout == "alpha out"
+        assert loaded_test.stderr == "alpha err"
+        assert loaded_test.finished
+        assert loaded_test.output_dir is not None
+        assert loaded_test.stdout_path is not None
+        assert loaded_test.stdout_path.read_text() == "alpha out"
+        assert loaded_test.stderr_path is not None
+        assert loaded_test.stderr_path.read_text() == "alpha err"
 
     asyncio.run(run_test())

--- a/tests/test_regression_runtime.py
+++ b/tests/test_regression_runtime.py
@@ -112,3 +112,16 @@ def test_regression_state_round_trips_with_test_outputs(tmp_path) -> None:
         assert loaded_test.stderr_path.read_text() == "alpha err"
 
     asyncio.run(run_test())
+
+
+def test_soft_reset_preserves_passed_tests() -> None:
+    test = Test(name="alpha", exec="echo ok")
+    test.status = TestStatus.Finished
+    test.result = TestResult.Passed
+    test.started_time = 1.0
+
+    test.soft_reset()
+
+    assert test.status is TestStatus.Finished
+    assert test.result is TestResult.Passed
+    assert test.started_time == 1.0

--- a/tests/test_regression_tui.py
+++ b/tests/test_regression_tui.py
@@ -2,16 +2,35 @@ from __future__ import annotations
 
 import re
 import asyncio
+from contextlib import contextmanager
 from textwrap import dedent
 from time import perf_counter
 
+from socx import settings
 from socx_tui.regression.app import SoCX
+from socx_tui.regression.dialog import TestOutputDialog as OutputDialog
 from socx_tui.regression.widget import RegressionWidget
 
 
 def _detail_text(widget: RegressionWidget) -> str:
     widget.details_view.refresh_details()
     return widget.details_view.document.source
+
+
+def _output_text(app: SoCX) -> str:
+    dialog = app.screen
+    assert isinstance(dialog, OutputDialog)
+    return dialog.query_one("#regression-output-area").text
+
+
+@contextmanager
+def _tui_output_dir(path):
+    original = settings.regression.run.output.directory
+    settings.regression.run.output.directory = path
+    try:
+        yield
+    finally:
+        settings.regression.run.output.directory = original
 
 
 async def _wait_for(predicate, max_wait: float = 3.0) -> None:
@@ -69,7 +88,8 @@ def test_regression_tui_loads_and_expands_regressions(tmp_path) -> None:
             assert "Script:" in details
             assert "echo alpha" in details
 
-    asyncio.run(run_test())
+    with _tui_output_dir(tmp_path / "workrun"):
+        asyncio.run(run_test())
 
 
 def test_regression_tui_can_run_pause_resume_and_restart(tmp_path) -> None:
@@ -126,5 +146,112 @@ def test_regression_tui_can_run_pause_resume_and_restart(tmp_path) -> None:
             assert marker.read_text().splitlines() == ["run", "run"]
             details = _detail_text(widget)
             assert bool(re.search(r"Result:.*passed", details, re.S))
+            assert bool(
+                re.search(
+                    r"Elapsed Time:.*\d{2}h:\d{2}m:\d{2}s", details, re.S
+                )
+            )
 
-    asyncio.run(run_test())
+    with _tui_output_dir(tmp_path / "workrun"):
+        asyncio.run(run_test())
+
+
+def test_regression_tui_persists_state_and_opens_output_modal(
+    tmp_path,
+) -> None:
+    path = tmp_path / "single.yaml"
+    path.write_text(
+        dedent(
+            """
+        smoke:
+              - name: alpha
+                exec:
+                  - printf alpha-out
+                  - printf alpha-err >&2
+                  - sleep 0.5
+        """
+        )
+    )
+
+    async def run_test() -> None:
+        saved_state_file = None
+        app = SoCX()
+
+        async with app.run_test() as pilot:
+            widget = app.query_one(RegressionWidget)
+            regression = await widget.load_regression_from_path(path)
+            test = regression.tests[0].tests[0]
+
+            assert not widget.refresh_enabled
+            await widget.action_start_selected()
+            await _wait_for(lambda: widget.refresh_enabled)
+            await _wait_for(
+                lambda: (
+                    test.status.name.lower() == "finished"
+                    and not widget.refresh_enabled
+                )
+            )
+
+            await pilot.press("space")
+            await pilot.pause()
+            await pilot.press("down")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OutputDialog)
+            output = _output_text(app)
+            assert "===== STDOUT =====" in output
+            assert "alpha-out" in output
+            assert "===== STDERR =====" in output
+            assert "alpha-err" in output
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            saved_state_file = regression.output_dir / "state.yaml"
+            app.exit()
+            await pilot.pause()
+
+        assert saved_state_file is not None
+        assert saved_state_file.exists()
+
+        restored_app = SoCX()
+        async with restored_app.run_test() as pilot:
+            widget = restored_app.query_one(RegressionWidget)
+            regression = await widget.load_regression_from_path(
+                saved_state_file
+            )
+            test = regression.tests[0].tests[0]
+
+            assert test.status.name.lower() == "finished"
+            assert test.stdout == "alpha-out"
+            assert test.stderr == "alpha-err"
+            details = _detail_text(widget)
+            assert bool(
+                re.search(r"Started Time:.*\d{4}-\d{2}-\d{2}", details, re.S)
+            )
+            assert bool(
+                re.search(r"Finished Time:.*\d{4}-\d{2}-\d{2}", details, re.S)
+            )
+            assert bool(
+                re.search(
+                    r"Elapsed Time:.*\d{2}h:\d{2}m:\d{2}s", details, re.S
+                )
+            )
+            assert bool(re.search(r"Progress:.*1/1.*100%", details, re.S))
+            assert bool(re.search(r"ETA:.*00h:00m:00s", details, re.S))
+
+            await pilot.press("space")
+            await pilot.pause()
+            await pilot.press("down")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            output = _output_text(restored_app)
+            assert "alpha-out" in output
+            assert "alpha-err" in output
+
+    with _tui_output_dir(tmp_path / "workrun"):
+        asyncio.run(run_test())


### PR DESCRIPTION
### Motivation

- Decouple execution, persistence and orchestration concerns from the `Regression` and `Test` models to support pluggable strategies and simplify models.
- Provide a default manager and runners so regressions/tests can be executed via injected strategies and persisted/loaded via a serializer abstraction.
- Improve the TUI restart behavior by allowing scoped restarts and soft resets so passed tests are preserved during selective reruns.

### Description

- Added a `RegressionManager` (`src/socx/regression/manager.py`) implementing high-level operations: `start`, `pause`, `resume`, `stop`, `restart`, `reset`, `soft_reset`, `dump_state`, `from_file`, and `load`, and exported `default_regression_manager`.
- Factored runner logic into `src/socx/regression/runners.py` with `DefaultTestRunner` and `DefaultRegressionRunner`, a shared semaphore, and exported `default_test_runner` and `default_regression_runner`.
- Factored serialization and state/file parsing into `src/socx/regression/serializers.py` with a `YamlRegressionSerializer` and exported `default_regression_serializer`; moved `_safe_dir_name`, coercion helpers, and state (de)serialization here.
- Updated `src/socx/regression/regression.py` to use the `RegressionManager` for lifecycle operations and to rely on the serializer and runners; removed inline runner/serialization code and added `kind` field and model wiring to use the default manager.
- Updated `src/socx/regression/test.py` to accept injected `runner` into `start`, added `soft_reset` on tests, and added `kind` to `TestBase`.
- Exported `RegressionManager` from `src/socx/regression/__init__.py`.
- TUI changes: added `RestartSelectionDialog` (`src/socx_tui/regression/dialog.py`) and changed the widget (`src/socx_tui/regression/widget.py`) to prompt restart scope and to perform scoped restarts using `soft_reset` for selective tests.
- Added `tests/test_regression_runtime.py::test_soft_reset_preserves_passed_tests` to assert `soft_reset` preserves passed tests.

### Testing

- Ran unit tests for the regression runtime tests with `pytest tests/test_regression_runtime.py`, which executed the updated test suite including `test_soft_reset_preserves_passed_tests` and completed successfully.
- Confirmed the new serializer/runner/manager integration by exercising `Regression.load`, `Regression.dump_state`, and test restart flows in the modified test scenarios (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bd51fcd600832ba7fe6b7d10567a81)